### PR TITLE
Remove duplicate PBXVariantGroup index to fix 'index ignored' warning.

### DIFF
--- a/lib/xcode/registry.rb
+++ b/lib/xcode/registry.rb
@@ -84,8 +84,7 @@ module Xcode
         'PBXContainerItemProxy' => ContainerItemProxy,
         'PBXBuildFile' => BuildFile,
         'PBXVariantGroup' => VariantGroup,
-        'XCConfigurationList' => ConfigurationList,
-        'PBXVariantGroup' => VariantGroup }[isa]
+        'XCConfigurationList' => ConfigurationList }[isa]
         
         Array(modules)
     end


### PR DESCRIPTION
This change fixes the following message:
'gems/xcoder-0.1.18/lib/xcode/registry.rb:86: warning: duplicated key at line 88 ignored: "PBXVariantGroup"'
